### PR TITLE
Räume -> Räume teilen: Hinweis zu Raum links und Einladungen hinzugefügt

### DIFF
--- a/content/rooms/sharing.en.md
+++ b/content/rooms/sharing.en.md
@@ -50,6 +50,8 @@ into the chat line. If you are a member of that room, you can confirm the auto-c
 
 The share icon at the top right of each room also offers a matrix.to-link, as well as a QR code and various social networks. The matrix.to-link leads to a page where you can select how the link should be opened. For example, the installed client Element Desktop can be used, or it can be selected via which home server the room is to be entered. 
 
+{{% notice note %}} People who receive the room address can only join immediately if the room is set to Public under Room Settings -> Security & Privacy -> Access or if their account was explicitly invited into the room. {{% /notice %}}
+
 ![share icon marked in the chat view of the room](/images/04_Sharing-Button_en.png)
 
 ```

--- a/content/rooms/sharing.md
+++ b/content/rooms/sharing.md
@@ -40,6 +40,8 @@ Erhält man solche Adressen auf anderem Wege (z.B. via E-Mail) hilft es, diese i
 
 Das Teilen-Symbol oben rechts in jedem Raum, bietet einen matrix.to-Link an, sowie einen QR-Code und verschiedene soziale Netzwerke. Der matrix.to- Link führt auf eine Seite, auf der ausgewählt werden kann, wie der Link geöffnet werden soll. So kann z.B. der installierte Client Element Desktop verwendet werden, oder ausgewählt werden, über welchen Heimserver der Raum betreten werden soll.
 
+{{% notice note %}} Damit Personen welche die Raumadresse als Link erhalten haben den Raum auch direkt betreten können, muss der Raum unter Raumeinstellungen -> Sicherheit -> Zutritt als Öffentlich markiert werden, oder die Person muss zusätzliche explizit in den Raum eingeladen werden. {{% /notice %}}
+
 ![Teilensymbol in der Chatansicht des Raums makiert](/images/04_Sharing-Button_de.png)
 
 <!--


### PR DESCRIPTION
Moin,

ich hab Hugo installiert aus den Paketquellen meines Ubuntu 24.04 LTS und wurde dann von dieser schönen Nachricht begrüsst:

Error: error building site: process: readAndProcessContent: "/home/niklas/git/gwdg/matrix-doc/content/clients/_index.en.md:13:10": failed to extract shortcode: template for shortcode "button" not found

D.h. ich habe die Änderung nicht getestet, aber hoffentlich funktioniert es trotzdem...

Liebe Grüsse,
Niklas